### PR TITLE
[#116]Feat: Card 순서 변경 기능 구현

### DIFF
--- a/src/main/java/org/nbc/account/trollo/domain/card/controller/CardController.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/controller/CardController.java
@@ -2,6 +2,7 @@ package org.nbc.account.trollo.domain.card.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.nbc.account.trollo.domain.card.converter.CardSequenceDirection;
 import org.nbc.account.trollo.domain.card.dto.request.CardCreateRequestDto;
 import org.nbc.account.trollo.domain.card.dto.request.CardUpdateRequestDto;
 import org.nbc.account.trollo.domain.card.dto.response.CardAllReadResponseDto;
@@ -78,6 +79,16 @@ public class CardController {
         @AuthenticationPrincipal UserDetailsImpl userDetails) {
         cardService.deleteCard(cardId, userDetails.getUser());
         return new ApiResponse<>(HttpStatus.OK.value(), "카드 삭제");
+    }
+
+    @PutMapping("/cards/{fromCardId}/to/{toCardId}/{direction}")
+    public ApiResponse<Void> updateCardSequence(
+        @PathVariable Long fromCardId,
+        @PathVariable Long toCardId,
+        @PathVariable CardSequenceDirection direction,
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        cardService.updateCardSequence(fromCardId, toCardId, direction, userDetails.getUser());
+        return new ApiResponse<>(HttpStatus.OK.value(), "카드 위치 변경");
     }
 
 }

--- a/src/main/java/org/nbc/account/trollo/domain/card/converter/CardSequenceDirection.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/converter/CardSequenceDirection.java
@@ -1,0 +1,5 @@
+package org.nbc.account.trollo.domain.card.converter;
+
+public enum CardSequenceDirection {
+    PREVIOUS, NEXT
+}

--- a/src/main/java/org/nbc/account/trollo/domain/card/converter/StringToCardSequenceDirectionConverter.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/converter/StringToCardSequenceDirectionConverter.java
@@ -1,0 +1,17 @@
+package org.nbc.account.trollo.domain.card.converter;
+
+import org.nbc.account.trollo.domain.card.exception.BadCardSequenceDirectionRequestException;
+import org.nbc.account.trollo.global.exception.ErrorCode;
+import org.springframework.core.convert.converter.Converter;
+
+public class StringToCardSequenceDirectionConverter implements Converter<String, CardSequenceDirection> {
+
+    @Override
+    public CardSequenceDirection convert(final String source) {
+        try {
+            return CardSequenceDirection.valueOf(source.toUpperCase());
+        } catch (Exception e){
+            throw new BadCardSequenceDirectionRequestException(ErrorCode.BAD_SEQUENCE_DIRECTION);
+        }
+    }
+}

--- a/src/main/java/org/nbc/account/trollo/domain/card/converter/StringToCardSequenceDirectionConverter.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/converter/StringToCardSequenceDirectionConverter.java
@@ -4,13 +4,14 @@ import org.nbc.account.trollo.domain.card.exception.BadCardSequenceDirectionRequ
 import org.nbc.account.trollo.global.exception.ErrorCode;
 import org.springframework.core.convert.converter.Converter;
 
-public class StringToCardSequenceDirectionConverter implements Converter<String, CardSequenceDirection> {
+public class StringToCardSequenceDirectionConverter implements
+    Converter<String, CardSequenceDirection> {
 
     @Override
     public CardSequenceDirection convert(final String source) {
         try {
             return CardSequenceDirection.valueOf(source.toUpperCase());
-        } catch (Exception e){
+        } catch (Exception e) {
             throw new BadCardSequenceDirectionRequestException(ErrorCode.BAD_SEQUENCE_DIRECTION);
         }
     }

--- a/src/main/java/org/nbc/account/trollo/domain/card/entity/Card.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/entity/Card.java
@@ -53,7 +53,7 @@ public class Card {
     private Card nextCard;
 
     @OneToMany(mappedBy = "card")
-    private List<CheckList> checkLists = new ArrayList<>();
+    private final List<CheckList> checkLists = new ArrayList<>();
 
     @Builder
     public Card(final String title, final String content, final String color,

--- a/src/main/java/org/nbc/account/trollo/domain/card/entity/Card.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/entity/Card.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.nbc.account.trollo.domain.card.converter.CardSequenceDirection;
 import org.nbc.account.trollo.domain.checklist.entity.CheckList;
 import org.nbc.account.trollo.domain.section.entity.Section;
 
@@ -80,5 +81,35 @@ public class Card {
         this.content = content;
         this.color = color;
         this.deadline = deadline;
+    }
+
+    public void changeSequence(final Card toCard, final CardSequenceDirection direction) {
+        if (prevCard != null) {
+            prevCard.setNextCard(nextCard);
+        }
+        if (nextCard != null) {
+            nextCard.setPrevCard(prevCard);
+        }
+
+        switch (direction) {
+            case PREVIOUS:
+                Card toCardPrevCard = toCard.getPrevCard();
+                if (toCardPrevCard != null) {
+                    toCardPrevCard.setNextCard(this);
+                }
+                toCard.setPrevCard(this);
+                this.setNextCard(toCard);
+                this.setPrevCard(toCardPrevCard);
+                break;
+            case NEXT:
+                Card toCardNextCard = toCard.getNextCard();
+                if (toCardNextCard != null) {
+                    toCardNextCard.setPrevCard(this);
+                }
+                toCard.setNextCard(this);
+                this.setPrevCard(toCard);
+                this.setNextCard(toCardNextCard);
+                break;
+        }
     }
 }

--- a/src/main/java/org/nbc/account/trollo/domain/card/exception/BadCardSequenceDirectionRequestException.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/exception/BadCardSequenceDirectionRequestException.java
@@ -1,0 +1,11 @@
+package org.nbc.account.trollo.domain.card.exception;
+
+import org.nbc.account.trollo.global.exception.CustomException;
+import org.nbc.account.trollo.global.exception.ErrorCode;
+
+public class BadCardSequenceDirectionRequestException extends CustomException {
+
+    public BadCardSequenceDirectionRequestException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/nbc/account/trollo/domain/card/exception/ForbiddenChangeCardSequenceException.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/exception/ForbiddenChangeCardSequenceException.java
@@ -1,0 +1,11 @@
+package org.nbc.account.trollo.domain.card.exception;
+
+import org.nbc.account.trollo.global.exception.CustomException;
+import org.nbc.account.trollo.global.exception.ErrorCode;
+
+public class ForbiddenChangeCardSequenceException extends CustomException {
+
+    public ForbiddenChangeCardSequenceException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/nbc/account/trollo/domain/card/exception/IllegalChangeSameCardException.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/exception/IllegalChangeSameCardException.java
@@ -1,0 +1,11 @@
+package org.nbc.account.trollo.domain.card.exception;
+
+import org.nbc.account.trollo.global.exception.CustomException;
+import org.nbc.account.trollo.global.exception.ErrorCode;
+
+public class IllegalChangeSameCardException extends CustomException {
+
+    public IllegalChangeSameCardException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/nbc/account/trollo/domain/card/service/CardService.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/service/CardService.java
@@ -1,6 +1,7 @@
 package org.nbc.account.trollo.domain.card.service;
 
 import java.util.List;
+import org.nbc.account.trollo.domain.card.converter.CardSequenceDirection;
 import org.nbc.account.trollo.domain.card.dto.request.CardCreateRequestDto;
 import org.nbc.account.trollo.domain.card.dto.request.CardUpdateRequestDto;
 import org.nbc.account.trollo.domain.card.dto.response.CardAllReadResponseDto;
@@ -21,4 +22,7 @@ public interface CardService {
     void updateCard(Long cardId, CardUpdateRequestDto cardUpdateRequestDto, User user);
 
     void deleteCard(Long cardId, User user);
+
+    void updateCardSequence(Long fromCardId, Long toCardId, CardSequenceDirection direction,
+        User user);
 }

--- a/src/main/java/org/nbc/account/trollo/domain/card/service/impl/CardServiceImpl.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/service/impl/CardServiceImpl.java
@@ -1,17 +1,21 @@
 package org.nbc.account.trollo.domain.card.service.impl;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.nbc.account.trollo.domain.board.entity.Board;
 import org.nbc.account.trollo.domain.board.exception.NotFoundBoardException;
 import org.nbc.account.trollo.domain.board.repository.BoardRepository;
+import org.nbc.account.trollo.domain.card.converter.CardSequenceDirection;
 import org.nbc.account.trollo.domain.card.dto.request.CardCreateRequestDto;
 import org.nbc.account.trollo.domain.card.dto.request.CardUpdateRequestDto;
 import org.nbc.account.trollo.domain.card.dto.response.CardAllReadResponseDto;
 import org.nbc.account.trollo.domain.card.dto.response.CardReadResponseDto;
 import org.nbc.account.trollo.domain.card.entity.Card;
 import org.nbc.account.trollo.domain.card.entity.Card.CardBuilder;
+import org.nbc.account.trollo.domain.card.exception.ForbiddenChangeCardSequenceException;
+import org.nbc.account.trollo.domain.card.exception.IllegalChangeSameCardException;
 import org.nbc.account.trollo.domain.card.exception.NotFoundCardException;
 import org.nbc.account.trollo.domain.card.mapper.CardMapper;
 import org.nbc.account.trollo.domain.card.repository.CardRepository;
@@ -152,6 +156,32 @@ public class CardServiceImpl implements CardService {
         cardRepository.delete(card);
     }
 
+    @Override
+    @Transactional
+    public void updateCardSequence(final Long fromCardId, final Long toCardId,
+        final CardSequenceDirection direction,
+        final User user) {
+        Card fromCard = cardRepository.findById(fromCardId)
+            .orElseThrow(() -> new NotFoundCardException(ErrorCode.NOT_FOUND_CARD));
+        Card toCard = cardRepository.findById(toCardId)
+            .orElseThrow(() -> new NotFoundCardException(ErrorCode.NOT_FOUND_CARD));
+
+        Long fromCardboardId = fromCard.getSection().getBoard().getId();
+        checkUserInBoard(fromCardboardId, user.getId());
+
+        Long toCardboardId = toCard.getSection().getBoard().getId();
+        checkUserInBoard(toCardboardId, user.getId());
+
+        if (!Objects.equals(fromCardboardId, toCardboardId)) {
+            throw new ForbiddenChangeCardSequenceException(ErrorCode.FORBIDDEN_CHANGE_CARD);
+        }
+
+        if (Objects.equals(fromCard, toCard)) {
+            throw new IllegalChangeSameCardException(ErrorCode.ILLEGAL_CHANGE_SAME_CARD);
+        }
+
+        fromCard.changeSequence(toCard, direction);
+    }
     private void checkUserInBoard(Long boardId, Long userId) {
         UserBoard userBoard = userBoardRepository.findByBoardIdAndUserId(boardId, userId)
             .orElseThrow(() -> new NotFoundUserBoardException(ErrorCode.NOT_FOUND_USER_BOARD));

--- a/src/main/java/org/nbc/account/trollo/domain/card/service/impl/CardServiceImpl.java
+++ b/src/main/java/org/nbc/account/trollo/domain/card/service/impl/CardServiceImpl.java
@@ -182,6 +182,7 @@ public class CardServiceImpl implements CardService {
 
         fromCard.changeSequence(toCard, direction);
     }
+
     private void checkUserInBoard(Long boardId, Long userId) {
         UserBoard userBoard = userBoardRepository.findByBoardIdAndUserId(boardId, userId)
             .orElseThrow(() -> new NotFoundUserBoardException(ErrorCode.NOT_FOUND_USER_BOARD));

--- a/src/main/java/org/nbc/account/trollo/global/config/WebConfig.java
+++ b/src/main/java/org/nbc/account/trollo/global/config/WebConfig.java
@@ -1,0 +1,15 @@
+package org.nbc.account.trollo.global.config;
+
+import org.nbc.account.trollo.domain.card.converter.StringToCardSequenceDirectionConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(final FormatterRegistry registry) {
+        registry.addConverter(new StringToCardSequenceDirectionConverter());
+    }
+}

--- a/src/main/java/org/nbc/account/trollo/global/exception/ErrorCode.java
+++ b/src/main/java/org/nbc/account/trollo/global/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     SELF_CANNOT_BE_INVITED(HttpStatus.BAD_REQUEST, "자기 자신은 보드에 초대될 수 없습니다."),
     ALREADY_EXIST_INVITATION(HttpStatus.BAD_REQUEST, "이미 초대된 사용자입니다."),
     ONLY_PARTICIPANTS_CAN_INVITE(HttpStatus.BAD_REQUEST, "보드 구성원만 다른 사람을 초대할 수 있습니다."),
-    BAD_SEQUENCE_DIRECTION(HttpStatus.BAD_REQUEST, "카드 순서는 above, below로만 바꿀 수 있습니다."),
+    BAD_SEQUENCE_DIRECTION(HttpStatus.BAD_REQUEST, "카드 순서는 previous/next로 바꿀 수 있습니다."),
     ILLEGAL_CHANGE_SAME_CARD(HttpStatus.BAD_REQUEST, "같은 카드에 대해서 순서를 바꿀 순 없습니다."),
 
     // 403

--- a/src/main/java/org/nbc/account/trollo/global/exception/ErrorCode.java
+++ b/src/main/java/org/nbc/account/trollo/global/exception/ErrorCode.java
@@ -15,13 +15,16 @@ public enum ErrorCode {
     BAD_LOGIN(HttpStatus.BAD_REQUEST, "이메일 또는 패스워드를 확인해주세요."),
     BAD_FORM(HttpStatus.BAD_REQUEST, "입력 형식이 맞지 않습니다."),
     INVALID_PASSWORD_CHECK(HttpStatus.BAD_REQUEST, "password check가 password와 일치하지 않습니다."),
-    SELF_CANNOT_BE_INVITED(HttpStatus.BAD_REQUEST,"자기 자신은 보드에 초대될 수 없습니다."),
-    ALREADY_EXIST_INVITATION(HttpStatus.BAD_REQUEST,"이미 초대된 사용자입니다."),
-    ONLY_PARTICIPANTS_CAN_INVITE(HttpStatus.BAD_REQUEST,"보드 구성원만 다른 사람을 초대할 수 있습니다."),
+    SELF_CANNOT_BE_INVITED(HttpStatus.BAD_REQUEST, "자기 자신은 보드에 초대될 수 없습니다."),
+    ALREADY_EXIST_INVITATION(HttpStatus.BAD_REQUEST, "이미 초대된 사용자입니다."),
+    ONLY_PARTICIPANTS_CAN_INVITE(HttpStatus.BAD_REQUEST, "보드 구성원만 다른 사람을 초대할 수 있습니다."),
+    BAD_SEQUENCE_DIRECTION(HttpStatus.BAD_REQUEST, "카드 순서는 above, below로만 바꿀 수 있습니다."),
+    ILLEGAL_CHANGE_SAME_CARD(HttpStatus.BAD_REQUEST, "같은 카드에 대해서 순서를 바꿀 순 없습니다."),
 
     // 403
     FORBIDDEN_ACCESS_CARD(HttpStatus.FORBIDDEN, "해당 카드에 접근할 수 없습니다."),
     FORBIDDEN_ACCESS_BOARD(HttpStatus.FORBIDDEN, "해당 보드에 접근할 수 없습니다."),
+    FORBIDDEN_CHANGE_CARD(HttpStatus.FORBIDDEN, "같은 보드에 속한 카드끼리만 순서를 바꿀 수 있습니다."),
 
     // 404
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾지 못하였습니다."),


### PR DESCRIPTION
## 작업 사항
Card 순서 변경 작업
- 같은 보드에 있는 카드끼리만 순서 변경 가능
- 서로 다른 색션에 있어도 순서 변경 가능
  - 순서 변경에 대한 로직은 Card 엔티티에 존재
- 빈 색션으로 이동은 아직 불가능(구현할 예정)
- 대상 카드로 이동시킬 방향 데이터를 담은 `CardSequenceDirection` enum 추가
  - 방향을 `above/below`가 아닌, `previous/next`로 설정
- `CardSequenceDirection` 를 스프링이 해석할 수 있도록 `StringToCardSequenceDirectionConverter` 추가

## 작업 목록
- Card
- CardService
- CardController
- CardSequenceDirection
- StringToCardSequenceDirectionConverter

## 수정 사항

## 관련 이슈
close #116